### PR TITLE
hfstol wrapper to support fast analysis in bulk

### DIFF
--- a/.idea/fst-lookup.iml
+++ b/.idea/fst-lookup.iml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.6 (fst-lookup)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="Unittests" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.6 (fst-lookup)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/fst-lookup.iml" filepath="$PROJECT_DIR$/.idea/fst-lookup.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Import the library, and load an FST from a file:
 ```python
 >>> from fst_lookup import FST
 >>> fst = FST.from_file('eat.fomabin')
+
 ```
 
 ### Assumed format of the FSTs
@@ -71,7 +72,6 @@ tags, or the _lemma_ (base form of the word).
  ('eat', '+V', '+3P', '+Sg')]
 ```
 
-
 ### Generate a word form
 
 To _generate_ a form (take a linguistic analysis, and get its concrete
@@ -87,6 +87,28 @@ a list.
 ```python
 >>> list(fst.generate('eat+V+Past')))
 ['ate']
+```
+
+### Analyze word forms in bulk efficiently
+
+To _analyze_ word forms in bulk, you have the option to use `hfst-optimized-lookup` program.
+Call the `analyze_in_bulk()` function. For large quatities of words, it can be two orders of magnitude faster than calling `analyze` one by one:
+
+It requires `hfst` executable installed and a `.hfstol` file. For linux system it can be an easy `sudo apt get install hfst`. For other systems check [this](https://github.com/hfst/hfst#installation).
+
+```python
+fst = FST.from_file(hfstol_path='my/English.hfstol')
+```
+
+```python
+def analyze_in_bulk(self, surface_forms: Iterable[str]) -> List[List[str]]
+```
+
+Note the output is produced by hfst and is different than `analyze`, basically it's the concatenated version
+
+```python
+>>> fst.analyze(['eats', 'balloons', 'jjksiwks', 'does'])
+[('eat+N+Mass', 'eat+V+3P+Sg'), ('balloon+N+Mass'), (''), ('do+V+3P+Sg')]
 ```
 
 

--- a/fst_lookup/fst.py
+++ b/fst_lookup/fst.py
@@ -52,9 +52,7 @@ class FST:
     A finite-state transducer that can convert between one string and a set of
     output strings.
     """
-    _parse: Optional[FSTParse]
-    _hfstol_exe_path: Optional[PathLike]
-    _hfstol_path: Optional[PathLike]
+
 
     def __init__(self, parse: Optional[FSTParse], hfstol_path: Optional[PathLike] = None,
                  hfstol_exe_path: Optional[PathLike] = None) -> None:

--- a/fst_lookup/fst.py
+++ b/fst_lookup/fst.py
@@ -113,7 +113,7 @@ class FST:
                 str(self._hfstol_exe_path),
                 "--quiet",
                 "--pipe-mode",
-                self._hfstol_path,
+                str(self._hfstol_path),
             ],
             input=lines,
             stdout=subprocess.PIPE,

--- a/fst_lookup/fst.py
+++ b/fst_lookup/fst.py
@@ -113,7 +113,7 @@ class FST:
 
         status = subprocess.run(
             [
-                self._hfstol_exe_path,
+                str(self._hfstol_exe_path),
                 "--quiet",
                 "--pipe-mode",
                 self._hfstol_path,
@@ -124,8 +124,7 @@ class FST:
             shell=False,
         )
 
-        analyses = []
-
+        analyses:HfstolAnalyses = []
 
         old_surface_form = None
         for line in status.stdout.decode("UTF-8").splitlines():

--- a/fst_lookup/fst.py
+++ b/fst_lookup/fst.py
@@ -53,7 +53,6 @@ class FST:
     output strings.
     """
 
-
     def __init__(self, parse: Optional[FSTParse], hfstol_path: Optional[PathLike] = None,
                  hfstol_exe_path: Optional[PathLike] = None) -> None:
 
@@ -122,7 +121,7 @@ class FST:
             shell=False,
         )
 
-        analyses:HfstolAnalyses = []
+        analyses= []  # type: HfstolAnalyses
 
         old_surface_form = None
         for line in status.stdout.decode("UTF-8").splitlines():

--- a/fst_lookup/fst.py
+++ b/fst_lookup/fst.py
@@ -142,10 +142,10 @@ class FST:
             surface_form, word_form, *rest = line.split("\t")
             if old_surface_form is None:
                 analyses.append([])
-                old_surface_form = surface_form
             else:
                 if surface_form != old_surface_form:
                     analyses.append([])
+            old_surface_form = surface_form
             # Generating this word form failed!
             if "+?" in rest:
                 analyses[-1].append('')


### PR DESCRIPTION
It doesn't change any old syntax/functionalities. the only addition is that in factory method `from_file`, you can specify extra hfstol file to use.