### PR TITLE
feat (analyze): added optional concatenated stems field to `analyze` output"

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,6 @@
 name: Build
 
 on: [push, pull_request]
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/fst_lookup/fst.py
+++ b/fst_lookup/fst.py
@@ -63,7 +63,7 @@ class FST:
 
     def analyze(self, surface_form: str, stemmer: bool = False) -> Analyses:
         """
-        Given a surface form, this yields all possible analyses (and stemms) in the FST.
+        Given a surface form, this yields all possible analyses (and optionally stems) in the FST.
         """
         try:
             symbols = list(self.to_symbols(surface_form))

--- a/fst_lookup/fst.py
+++ b/fst_lookup/fst.py
@@ -61,9 +61,9 @@ class FST:
         for arc in parse.arcs:
             self.arcs_from[arc.state].add(arc)
 
-    def analyze(self, surface_form: str) -> Analyses:
+    def analyze(self, surface_form: str, stemmer: bool = False) -> Analyses:
         """
-        Given a surface form, this yields all possible analyses in the FST.
+        Given a surface form, this yields all possible analyses (and stemms) in the FST.
         """
         try:
             symbols = list(self.to_symbols(surface_form))
@@ -75,7 +75,10 @@ class FST:
             get_output_label=lambda arc: arc.upper,
         )
         for analysis, stems in analyses:
-            yield tuple(self._format_transduction(analysis)), stems
+            if stemmer:
+                yield tuple(self._format_transduction(analysis)), stems
+            else:
+                yield tuple(self._format_transduction(analysis))
 
     def generate(self, analysis: str) -> Iterable[str]:
         """


### PR DESCRIPTION
Changes:
- added concatenated input stems in the analyze output as a different field (stemmer)
- added an optional 'stemmer' argument for the analyze function to receive stems only when you selected that.

Details:
I tried to keep the extra code to a minimum and to ensure it is in harmony with the rest of the repo. For some use cases, a Stemmer is crucial, and in this case, it adds nothing to processing/memory order of the program and can easily be ignored if we do not need it. Without this feature, there should be an extra FST that has been compiled based on the stemmer structure in the new LEXC files. But in this manner, we have it naturally in the process.

Example:
cows -> cow+N+Pl,    cow+s
sheep -> sheep+N+Sg,   sheep